### PR TITLE
Review ccip integration script roles

### DIFF
--- a/CCIP_INTEGRATION.md
+++ b/CCIP_INTEGRATION.md
@@ -98,8 +98,8 @@ forge test --gas-report
 ## Example Integration Script
 
 ```solidity
-// Example script to set up CCIP roles
-contract SetupCCIPRoles is Script {
+// Example script to set up CCIP roles on DESTINATION chain
+contract SetupCCIPRolesDestination is Script {
     function run() external {
         address tokenAddress = 0x...; // Your deployed token
         address ccipPoolAddress = 0x...; // Official CCIP pool
@@ -109,8 +109,25 @@ contract SetupCCIPRoles is Script {
         
         BurnMintERC677 token = BurnMintERC677(tokenAddress);
         
-        // Grant roles to CCIP pool
+        // On destination chain - grant ONLY mint role
         token.grantMintRole(ccipPoolAddress);
+        
+        vm.stopBroadcast();
+    }
+}
+
+// Example script to set up CCIP roles on SOURCE chain
+contract SetupCCIPRolesSource is Script {
+    function run() external {
+        address tokenAddress = 0x...; // Your deployed token
+        address ccipPoolAddress = 0x...; // Official CCIP pool
+        
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        
+        BurnMintERC677 token = BurnMintERC677(tokenAddress);
+        
+        // On source chain - grant ONLY burn role
         token.grantBurnRole(ccipPoolAddress);
         
         vm.stopBroadcast();


### PR DESCRIPTION
Refactor CCIP role setup example to grant specific roles based on chain, addressing a security review comment.

The original example granted both mint and burn roles to the CCIP pool, which violated the principle of least privilege and contradicted the documentation's guidance. This change splits the example into separate scripts for source and destination chains, ensuring only the necessary role (burn for source, mint for destination) is granted, thereby enhancing security and clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-fddbb958-c9bd-4a35-8d2a-a29d3b6671e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fddbb958-c9bd-4a35-8d2a-a29d3b6671e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>