### PR TITLE
Fix missing openzeppelin contracts dependency

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,3 @@
-@openzeppelin/=lib/openzeppelin-contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 @chainlink/contracts-ccip/=lib/ccip/contracts/
 forge-std/=lib/forge-std/src/


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update OpenZeppelin remapping in `remappings.txt` to resolve Forge compilation errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous remapping `@openzeppelin/` was incomplete, leading to "No such file or directory" errors for imports like `@openzeppelin/contracts/token/ERC20/IERC20.sol`. The updated remapping `@openzeppelin/contracts/` correctly maps the import paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-5be28da2-e7b8-474f-bac9-3b9dcc1dc51e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5be28da2-e7b8-474f-bac9-3b9dcc1dc51e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>